### PR TITLE
feat(tracing): add tracing and debug info

### DIFF
--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -6,10 +6,10 @@ pub mod tls;
 pub mod udp;
 pub mod utils;
 
-use std::{any::Any, net::IpAddr, sync::Arc};
+use std::{any::Any, fmt::Debug, net::IpAddr, sync::Arc};
 
 /// The `Analyzer` trait defines the basic interface for all analyzers.
-pub trait Analyzer: Any + Send + Sync {
+pub trait Analyzer: Any + Send + Sync + Debug {
     /// Get the name of the analyzer.
     ///
     /// # Returns
@@ -182,6 +182,7 @@ mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+    #[derive(Debug)]
     struct DummyAnalyzer;
 
     impl Analyzer for DummyAnalyzer {
@@ -217,6 +218,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
     struct DummyTCPAnalyzer;
 
     impl Analyzer for DummyTCPAnalyzer {
@@ -251,6 +253,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
     struct DummyUDPAnalyzer;
 
     impl Analyzer for DummyUDPAnalyzer {

--- a/analyzer/src/tcp/http.rs
+++ b/analyzer/src/tcp/http.rs
@@ -7,6 +7,7 @@ use bytes::BytesMut;
 use crate::*;
 
 /// HTTPAnalyzer is an analyzer for HTTP protocol.
+#[derive(Debug)]
 pub struct HTTPAnalyzer {}
 
 impl HTTPAnalyzer {

--- a/analyzer/src/udp/dns.rs
+++ b/analyzer/src/udp/dns.rs
@@ -31,6 +31,7 @@ const DNS_UDP_INVALID_COUNT_THRESHOLD: u32 = 4;
 
 /// `DNSAnalyzer` should implement traits `UDPAnalyzer` and `TCPAnalyzer`(which two implement trait
 /// `Analyzer`).
+#[derive(Debug)]
 pub struct DNSAnalyzer {}
 
 impl DNSAnalyzer {

--- a/analyzer/src/udp/openvpn.rs
+++ b/analyzer/src/udp/openvpn.rs
@@ -46,6 +46,7 @@ const OPENVPN_UDP_PKT_DEFAULT_LIMIT: u32 = 256;
 
 /// `OpenVPNAnalyzer` implements traits `UDPAnalyzer` andd `TCPAnalyzer`.
 /// This struct is responsible for creating new UDP and TCP streams for OpenVPN analysis.
+#[derive(Debug)]
 pub struct OpenVPNAnalyzer {}
 
 impl OpenVPNAnalyzer {

--- a/analyzer/src/udp/wireguard.rs
+++ b/analyzer/src/udp/wireguard.rs
@@ -61,6 +61,7 @@ const WIREGUARD_SIZE_PACKET_COOKIE_REPLY: u32 = 64;
 /// This structure is responsible for creating new instances of `WireGuardUDPStream`
 /// and providing basic information about the analyzer.
 
+#[derive(Debug)]
 pub struct WireGuardAnalyzer {}
 
 impl WireGuardAnalyzer {

--- a/engine/src/worker.rs
+++ b/engine/src/worker.rs
@@ -16,7 +16,7 @@ use tokio::{
     sync::{mpsc, RwLock},
     time,
 };
-use tracing::{error, info};
+use tracing::{debug, error};
 
 use crate::{
     tcp::{TCPContext, TCPStreamFactory, TCPStreamManager, TCPVerdict},
@@ -45,6 +45,7 @@ pub struct WorkerPacket {
 }
 
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct Worker {
     id: i32,
 
@@ -129,6 +130,7 @@ impl Worker {
     /// # Returns
     ///
     /// A `Result` indicating success or failure.
+    #[tracing::instrument(level = "debug")]
     pub async fn run(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
         let mut tcp_flush_interval = time::interval(TCP_FLUSH_INTERVAL);
 
@@ -297,7 +299,7 @@ impl Worker {
     async fn flush_tcp(&mut self, timeout: Duration) {
         let (flushed, closed) = self.tcp_stream_manager.flush_close_older_than(timeout);
 
-        info!(
+        debug!(
             "[TCP flush]: worker_id: {:?}, flushed: {:?}, closed: {:?}",
             self.id, flushed, closed
         );

--- a/modifier/src/lib.rs
+++ b/modifier/src/lib.rs
@@ -9,11 +9,12 @@
 
 pub mod udp;
 
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::{any::Any, collections::HashMap};
 
 /// The `Modifier` trait allows for the creation of new instances of modifiers with specific arguments.
-pub trait Modifier: Send + Sync {
+pub trait Modifier: Send + Sync + Debug {
     /// Returns the name of the modifier.
     fn name(&self) -> &str;
 
@@ -31,7 +32,7 @@ pub trait Modifier: Send + Sync {
 }
 
 /// The `Instance` trait is a marker trait for instances of modifiers.
-pub trait Instance: Any + Send + Sync {
+pub trait Instance: Any + Send + Sync + Debug {
     fn as_any(&self) -> &dyn Any;
 }
 

--- a/modifier/src/udp/dns.rs
+++ b/modifier/src/udp/dns.rs
@@ -14,6 +14,7 @@ use std::{
 use tracing::{self, error, warn};
 
 /// A DNS modifier that implements the `Modifier` trait.
+#[derive(Debug)]
 pub struct DNSModifier;
 
 impl DNSModifier {
@@ -85,6 +86,7 @@ impl Modifier for DNSModifier {
 }
 
 /// An instance of the DNS modifier containing the IPv4 and IPv6 addresses.
+#[derive(Debug)]
 struct DNSModifierInstance {
     a: Ipv4Addr,
     aaaa: Ipv6Addr,

--- a/ruleset/src/expr_rule.rs
+++ b/ruleset/src/expr_rule.rs
@@ -40,6 +40,7 @@ pub async fn read_expr_rules_from_file(
     Ok(expr_rules)
 }
 
+#[derive(Debug)]
 pub struct CompiledExprRule {
     pub name: String,
     pub action: Action,
@@ -47,6 +48,7 @@ pub struct CompiledExprRule {
     pub ast: rhai::AST,
 }
 
+#[derive(Debug)]
 pub struct ExprRuleset {
     pub engine: Arc<rhai::Engine>,
     pub rules: Vec<CompiledExprRule>,

--- a/ruleset/src/lib.rs
+++ b/ruleset/src/lib.rs
@@ -1,12 +1,13 @@
 use nt_analyzer::Analyzer;
 use nt_modifier::Instance;
 use serde::Deserialize;
-use std::fmt;
+use std::fmt::{self, Debug};
 use std::net::IpAddr;
 use std::sync::Arc;
 
 pub mod expr_rule;
 
+#[derive(Debug)]
 pub enum Protocol {
     TCP,
     UDP,
@@ -32,6 +33,7 @@ pub enum Action {
     Modify,
 }
 
+#[derive(Debug)]
 pub struct StreamInfo {
     pub id: i64,
     pub protocol: Protocol,
@@ -48,7 +50,7 @@ pub struct MatchResult {
 }
 
 /// The ruleset trait.
-pub trait Ruleset: Send + Sync {
+pub trait Ruleset: Send + Sync + Debug {
     /// - returns the list of analyzers to use for a stream.
     ///
     /// It must be safe for concurrent use by multiple workers.


### PR DESCRIPTION
Add tracing to the engine (which is originally defined in cmd/root.go).