### PR TITLE
fix: fix the shutdown logic, use cancellation tokens to replace original signals.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 [workspace.dependencies]
 axum = "0.7.7"
 tokio = { version = "1.41.1", features = ["full"] }
-async_trait = { version = "0.1" }
+tokio-util = { version = "0.7.13", features = ["rt"] }
 tower = "0.5.1"
 clap = { version = "4.5.20", features = ["derive"] }
 tracing = "0.1"
@@ -30,7 +30,6 @@ snafu = "0.8.5"
 
 ## workspace members
 nt-analyzer = { package = "analyzer", path = 'analyzer' }
-nt-apiserver = { package = "apiserver", path = 'apiserver' }
 nt-cmd = { package = "cmd", path = 'cmd' }
 nt-engine = { package = "engine", path = 'engine' }
 nt-io = { package = "io", path = 'io' }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-# net-guardian
-Rewrite [opengfw](https://github.com/apernet/OpenGFW) in Rust.
+# gfw-rs
+Rewrite [OpenGFW](https://github.com/apernet/OpenGFW) in Rust.
+
 
 > [!CAUTION]
 > This project is still in very early stages of development. Use at your own risk.
 
 
 ## Features
-* Written in Rust, focusing on performance and safety.
-* Full IP/TCP reassembly, various protocol analyzers.
-* a Web-UI which facilitates configuration and monitering.
+* High concurrency and fast I/O processing speed: The core engine utilizes Rust's Tokio asynchronous runtime, ensuring excellent concurrency performance and rapid I/O processing capabilities.
+* Multi-protocol support: Supports the parsing of multiple network protocols, providing rich packet information to meet diverse network analysis needs.
+* Flexible rule definition: Rules are defined using the Rhai scripting language, allowing users to customize matching rules in various ways and apply corresponding actions to matched network packets.
+* Streamlined frontend interface: Includes a user-friendly frontend interface that supports custom configuration and log visualization, enhancing the overall user experience.
+
 
 ## WIP
 See [this issue](https://github.com/tkob-vh/net-guardian/issues/22)
 
 ##  Requriements
-* The kernel modules about `conntrack` should be loaded.
+* The kernel modules about the connection tracking system should be loaded.
 * Need root permission to modify the nftables/iptables and `conntrack` system.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,15 @@ Rewrite [OpenGFW](https://github.com/apernet/OpenGFW) in Rust.
 See [this issue](https://github.com/tkob-vh/net-guardian/issues/22)
 
 ##  Requriements
+* Make sure you have cargo installed on your system.
 * The kernel modules about the connection tracking system should be loaded.
 * Need root permission to modify the nftables/iptables and `conntrack` system.
+
+## How to run
+For now, you can execute
+```
+cargo run --bin cmd -- --config-file config.yaml --ruleset-file rules.yaml --log-level debug
+```
+to run this program.
+
+For the frontend, we are currently refactoring it so it is not stable now.

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -20,3 +20,4 @@ nt-io.workspace = true
 rhai.workspace = true
 nt-engine.workspace = true
 snafu.workspace = true
+tokio-util = "0.7.13"

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -5,7 +5,7 @@ use nt_modifier::Modifier;
 use nt_ruleset::expr_rule::ExprRuleset;
 use std::error::Error;
 use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc::Sender, RwLock};
+use tokio::sync::{broadcast, RwLock};
 use tracing_subscriber::fmt::MakeWriter;
 
 pub mod file;
@@ -62,6 +62,7 @@ pub struct ServerConfig {
     pub io_impl: Option<Arc<dyn PacketIO>>,
 
     /// shutdown also stand for the engine is running.
-    pub shutdown: Option<Sender<()>>,
+    //pub shutdown: Option<Sender<()>>,
+    pub engine_cancellation_token: tokio_util::sync::CancellationToken,
     pub engine_handler: Option<tokio::task::JoinHandle<Result<(), Box<dyn Error + Send + Sync>>>>,
 }

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -64,5 +64,6 @@ pub struct ServerConfig {
     /// shutdown also stand for the engine is running.
     //pub shutdown: Option<Sender<()>>,
     pub engine_cancellation_token: tokio_util::sync::CancellationToken,
+    pub program_cancellation_token: tokio_util::sync::CancellationToken,
     pub engine_handler: Option<tokio::task::JoinHandle<Result<(), Box<dyn Error + Send + Sync>>>>,
 }

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -32,7 +32,12 @@ async fn main() {
         config: Arc::new(nt_cmd::config::CliConfig::default()),
         io_impl: None,
         rule_set: None,
-        engine_cancellation_token: tokio_util::sync::CancellationToken::default(),
+        engine_cancellation_token: {
+            let token = tokio_util::sync::CancellationToken::default();
+            token.cancel();
+            token
+        },
+        program_cancellation_token: tokio_util::sync::CancellationToken::new(),
         engine_handler: None,
     }))));
 

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
         config: Arc::new(nt_cmd::config::CliConfig::default()),
         io_impl: None,
         rule_set: None,
-        shutdown: None,
+        engine_cancellation_token: tokio_util::sync::CancellationToken::default(),
         engine_handler: None,
     }))));
 

--- a/apiserver/src/service.rs
+++ b/apiserver/src/service.rs
@@ -98,20 +98,20 @@ async fn start_service(server: Extension<SharedServerConfig>) -> Result<String, 
     });
 
     let (_config_tx, config_rx) = tokio::sync::watch::channel(());
+    let (service_tx, _service_rx) = tokio::sync::watch::channel(true);
 
     info!("Engine started");
 
     // Run the engine until shutdown signal
     let engine_handle = tokio::spawn({
         let program_cancellation_token = server_config.program_cancellation_token.clone();
-        let engine_cancellation_token = server_config.engine_cancellation_token.clone();
         let analyzers = server_config.analyzers.clone();
         let modifiers = server_config.modifiers.clone();
         async move {
             engine
                 .run(
                     program_cancellation_token,
-                    engine_cancellation_token,
+                    service_tx,
                     config_rx,
                     "None".to_owned(),
                     analyzers,

--- a/apiserver/src/service.rs
+++ b/apiserver/src/service.rs
@@ -97,7 +97,7 @@ async fn start_service(server: Extension<SharedServerConfig>) -> Result<String, 
         }
     });
 
-    let (_config_tx, config_rx) = tokio::sync::watch::channel(());
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(());
     let (service_tx, _service_rx) = tokio::sync::watch::channel(true);
 
     info!("Engine started");
@@ -112,7 +112,7 @@ async fn start_service(server: Extension<SharedServerConfig>) -> Result<String, 
                 .run(
                     program_cancellation_token,
                     service_tx,
-                    config_rx,
+                    config_tx,
                     "None".to_owned(),
                     analyzers,
                     modifiers,

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -18,3 +18,4 @@ nt-analyzer.workspace = true
 nt-modifier.workspace = true
 rhai.workspace = true
 notify = "7.0.0"
+tokio-util.workspace = true

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -142,7 +142,7 @@ async fn main() {
     });
 
     // Handle file monitoring for config reload
-    let (config_tx, config_rx) = tokio::sync::watch::channel(());
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(());
 
     tracker.spawn({
         let ruleset_file = cli.ruleset_file.clone();
@@ -213,7 +213,7 @@ async fn main() {
                 .run(
                     program_cancellation_token,
                     service_tx,
-                    config_rx,
+                    config_tx,
                     cli.ruleset_file.clone(),
                     analyzers,
                     modifiers,

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -16,6 +16,7 @@ pnet.workspace = true
 rhai.workspace = true
 rs-snowflake = "0.6.0"
 tokio.workspace = true
+tokio-util = "0.7.13"
 tracing.workspace = true
 
 [dev-dependencies]

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -81,7 +81,7 @@ impl crate::Engine for Engine {
         &mut self,
         program_cancellation_token: tokio_util::sync::CancellationToken,
         service_tx: tokio::sync::watch::Sender<bool>,
-        mut config_rx: tokio::sync::watch::Receiver<()>,
+        config_tx: tokio::sync::watch::Sender<()>,
         ruleset_file: String,
         analyzers: Vec<Arc<dyn nt_analyzer::Analyzer>>,
         modifiers: Vec<Arc<dyn nt_modifier::Modifier>>,
@@ -130,6 +130,7 @@ impl crate::Engine for Engine {
         self.io.register(packet_handler, service_rx).await?;
 
         let io = self.io.clone();
+        let mut config_rx = config_tx.subscribe();
         // Wait for either error or shutdown signal or ruleset reload.
         loop {
             tokio::select! {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -139,7 +139,8 @@ impl crate::Engine for Engine {
                 }
                 _ = program_cancellation_token.cancelled() => {
                     info!("Shutdown the gfw engine...");
-                    engine_cancellation_token.cancel();
+
+                    // Delete the nftables.
                     io.close().await;
                     return Ok(());
                 }

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -129,6 +129,7 @@ impl crate::Engine for Engine {
         // Register packet handler
         self.io.register(Box::new(packet_handler)).await?;
 
+        let io = self.io.clone();
         // Wait for either error or shutdown signal or ruleset reload.
         loop {
             tokio::select! {
@@ -139,6 +140,7 @@ impl crate::Engine for Engine {
                 _ = program_cancellation_token.cancelled() => {
                     info!("Shutdown the gfw engine...");
                     engine_cancellation_token.cancel();
+                    io.close().await;
                     return Ok(());
                 }
                 _ = config_rx.changed() => {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -80,6 +80,7 @@ impl crate::Engine for Engine {
     async fn run(
         &mut self,
         program_cancellation_token: tokio_util::sync::CancellationToken,
+        engine_cancellation_token: tokio_util::sync::CancellationToken,
         mut config_rx: tokio::sync::watch::Receiver<()>,
         ruleset_file: String,
         analyzers: Vec<Arc<dyn nt_analyzer::Analyzer>>,
@@ -87,7 +88,6 @@ impl crate::Engine for Engine {
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         let (err_tx, mut err_rx) = mpsc::channel::<Box<dyn Error + Send + Sync>>(1);
         let (rs_tx, mut _rs_rx) = tokio::sync::broadcast::channel(self.workers.len());
-        let engine_cancellation_token = tokio_util::sync::CancellationToken::new();
 
         debug!("Start workers.");
         for mut worker in std::mem::take(&mut self.workers) {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -19,7 +19,7 @@ pub trait Engine {
     /// Run runs the engine, until an error occurs or the context is cancelled.
     async fn run(
         &mut self,
-        mut shutdone_rx: tokio::sync::mpsc::Receiver<()>,
+        program_cancellation_token: tokio_util::sync::CancellationToken,
         mut config_rx: tokio::sync::watch::Receiver<()>,
         ruleset_file: String,
         analyzers: Vec<Arc<dyn nt_analyzer::Analyzer>>,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -20,6 +20,7 @@ pub trait Engine {
     async fn run(
         &mut self,
         program_cancellation_token: tokio_util::sync::CancellationToken,
+        engine_cancellation_token: tokio_util::sync::CancellationToken,
         mut config_rx: tokio::sync::watch::Receiver<()>,
         ruleset_file: String,
         analyzers: Vec<Arc<dyn nt_analyzer::Analyzer>>,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -21,7 +21,7 @@ pub trait Engine {
         &mut self,
         program_cancellation_token: tokio_util::sync::CancellationToken,
         service_tx: tokio::sync::watch::Sender<bool>,
-        mut config_rx: tokio::sync::watch::Receiver<()>,
+        config_tx: tokio::sync::watch::Sender<()>,
         ruleset_file: String,
         analyzers: Vec<Arc<dyn nt_analyzer::Analyzer>>,
         modifier: Vec<Arc<dyn nt_modifier::Modifier>>,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -20,7 +20,7 @@ pub trait Engine {
     async fn run(
         &mut self,
         program_cancellation_token: tokio_util::sync::CancellationToken,
-        engine_cancellation_token: tokio_util::sync::CancellationToken,
+        service_tx: tokio::sync::watch::Sender<bool>,
         mut config_rx: tokio::sync::watch::Receiver<()>,
         ruleset_file: String,
         analyzers: Vec<Arc<dyn nt_analyzer::Analyzer>>,

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -124,6 +124,8 @@ pub trait PacketIO: DowncastSync + Send + Sync {
         &self,
         cancel_func: Box<dyn Fn() + Send + Sync>,
     ) -> Result<(), Box<dyn Error + Send + Sync>>;
+
+    async fn close(&self);
 }
 
 impl_downcast!(sync PacketIO);

--- a/io/src/nfqueue.rs
+++ b/io/src/nfqueue.rs
@@ -652,6 +652,17 @@ impl PacketIO for NFQueuePacketIO {
         // NFQueue doesn't need cancel functionality
         Ok(())
     }
+
+    async fn close(&self) {
+        let mut rule_set = self.rule_set.lock().await;
+        if *rule_set {
+            self.setup_nft(true)
+                .await
+                .expect("Failed to delete nftables");
+
+            *rule_set = false;
+        }
+    }
 }
 
 struct NFQueuePacket {

--- a/io/src/pcap.rs
+++ b/io/src/pcap.rs
@@ -192,11 +192,6 @@ impl PacketIO for PcapPacketIO {
         Ok(TcpStream::connect(addr).await.unwrap())
     }
 
-    //async fn close(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-    //    // File will be closed when the Arc/Mutex is dropped
-    //    Ok(())
-    //}
-
     async fn set_cancel_func(
         &self,
         cancel_func: Box<dyn Fn() + Send + Sync>,
@@ -205,6 +200,8 @@ impl PacketIO for PcapPacketIO {
         *func = Some(cancel_func);
         Ok(())
     }
+
+    async fn close(&self) {}
 }
 
 /// Struct representing a pcap packet.


### PR DESCRIPTION
目前有一个token，控制整个程序的运行。
`program_cancellation_token`: 接收到 `ctrlc` 时，触发该相应的`cancel()`, 并退出 `engine`（包括`workers`）以及`ruleset watcher`.

gfw的动态启动/暂停 通过`tokio::sync::watch::channel(bool)`实现。`true`代表当前状态为active（默认），`false`则代表为inactive.

目前在register中判断这个状态是否为false, 是则直接accept这个包，不经过后续处理。